### PR TITLE
Documentation Improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ to auto-load on your sgml modes:
 
     (add-hook 'sgml-mode-hook 'zencoding-mode) ;; Auto-start on any markup modes
 
-Good to go.
+Good to go: place point in a zencoding snippet and press C-j to expand it (or 
+alternatively, alias your preferred keystroke to M-x zencoding-expand-line) and
+you'll transform your snippet into the appropriate tag structure. 
 
 # Examples
 


### PR DESCRIPTION
Added the default emacs key combination and M-x command for zencode expansion. Though we wish otherwise, source is not its own documentation, and the README's silence on how to activate the central function of the mode is a Bad Thing. 
