### PR TITLE
Replaced fixed 4-space indentation with dynamic indentation.

### DIFF
--- a/zencoding-mode.el
+++ b/zencoding-mode.el
@@ -550,10 +550,26 @@
             (sib2 (zencoding-transform-ast (caddr ast) tag-maker)))
         (concat sib1 "\n" sib2))))))
 
+(defun zencoding-indent-size ()
+  "Calculate indent size using current mode as a guidance"
+  (let ((mode (with-current-buffer (current-buffer) major-mode)))
+    (cond
+     ((string= mode "nxml-mode") nxml-child-indent)
+     ((string= mode "html-mode") sgml-basic-offset)
+     ((string= mode "sgml-mode") sgml-basic-offset)
+     (t 4)
+     ))
+  )
+
 (defun zencoding-indent (text)
   "Indent the text"
   (if text
-      (replace-regexp-in-string "\n" "\n    " (concat "\n" text))
+      (replace-regexp-in-string
+       "\n"
+       (concat
+        "\n"
+        (make-string (zencoding-indent-size) ?\ ))
+       (concat "\n" text))
     nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
The idea behind this change is to make zencoding respect custom indentation size setting in the current buffer.
